### PR TITLE
Reduce ksrc search output duplication

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ksrc",
   "description": "Ksrc CLI skill for searching/reading Kotlin dependency sources",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "repository": "https://github.com/respawn-app/ksrc"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ksrc",
   "description": "Ksrc CLI skill for searching/reading Kotlin dependency sources",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "repository": "https://github.com/respawn-app/ksrc"
 }

--- a/docs/cli-api.md
+++ b/docs/cli-api.md
@@ -73,7 +73,7 @@ ksrc search [<module>] -q <pattern> [flags] [-- <rg-args>]
 - `--emit-id <always|auto|never>`: Include file identifiers (default: `always`)
 
 **Output (default)**
-`<file-id> <inner-path>:<line>:<col>:<match>` (rg‑compatible with leading file id; use `--show-extracted-path` for temp paths)
+`<file-id> <line>:<col>:<match>` (use `--show-extracted-path` to include temp paths)
 
 **Aliases**
 - `ksrc rg` is an alias of `ksrc search`

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -68,7 +68,8 @@ func TestSearchContextAndPassThrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("search error: %v", err)
 	}
-	if !strings.Contains(ctxOut, " "+inner+":1:0:before") || !strings.Contains(ctxOut, " "+inner+":3:0:after") {
+	fileID := "org.jetbrains.kotlinx:kotlinx-datetime:0.6.1!/" + inner
+	if !strings.Contains(ctxOut, fileID+" 1:0:before") || !strings.Contains(ctxOut, fileID+" 3:0:after") {
 		t.Fatalf("context lines missing: %s", ctxOut)
 	}
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -81,14 +81,11 @@ func newSearchCmd(app *App) *cobra.Command {
 				return err
 			}
 			for _, m := range matches {
-				path := m.File
-				if !showExtractedPath {
-					path = fileIDInnerPath(m.FileID)
-					if path == "" {
-						path = "<src>"
-					}
+				if showExtractedPath {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s %s:%d:%d:%s\n", m.FileID, m.File, m.Line, m.Column, m.Text)
+					continue
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s %s:%d:%d:%s\n", m.FileID, path, m.Line, m.Column, m.Text)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %d:%d:%s\n", m.FileID, m.Line, m.Column, m.Text)
 			}
 			return nil
 		},
@@ -112,12 +109,4 @@ func newSearchCmd(app *App) *cobra.Command {
 	cmd.Flags().IntVar(&contextLines, "context", 0, "show N lines before/after matches (rg -C)")
 
 	return cmd
-}
-
-func fileIDInnerPath(fileID string) string {
-	parts := strings.SplitN(fileID, "!/", 2)
-	if len(parts) != 2 {
-		return ""
-	}
-	return parts[1]
 }

--- a/skills/ksrc/SKILL.md
+++ b/skills/ksrc/SKILL.md
@@ -31,7 +31,7 @@ Common flags:
 - `--show-extracted-path` include temp extracted paths in output (off by default)
 
 Output format:
-`<file-id> <inner-path>:<line>:<col>:<match>` (use `--show-extracted-path` for temp paths)
+`<file-id> <line>:<col>:<match>` (use `--show-extracted-path` for temp paths)
 
 ### `ksrc cat <file-id|path>`
 Print file contents.


### PR DESCRIPTION
## Summary
- drop redundant inner path from default search output to reduce token usage
- update docs and tests for new format
- bump plugin version to 0.1.2

## Testing
- go test ./...