### PR TITLE
Improve install script error handling

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,7 +170,15 @@ esac
 
 mkdir -p "$bin_dir"
 target="$bin_dir/ksrc"
-if [ -f "$target" ]; then
+if [ -e "$target" ]; then
+  if [ -d "$target" ]; then
+    echo "Refusing to overwrite directory $target" >&2
+    exit 1
+  fi
+  if [ -L "$target" ]; then
+    echo "Refusing to overwrite symlink $target" >&2
+    exit 1
+  fi
   echo "Warning: overwriting existing $target" >&2
 fi
 install -m 755 "$tmpdir/$bin_name" "$target"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,10 +8,10 @@ RELEASE_BASE="${KSRC_RELEASE_BASE:-https://github.com/${REPO}/releases/download}
 
 usage() {
   cat <<EOF
-Usage: install.sh [--version vX.Y.Z] [--prefix /path]
+Usage: install.sh [--version vX.Y.Z|X.Y.Z] [--prefix /path]
 
 Options:
-  --version  Release tag to install (defaults to latest)
+  --version  Release tag to install (vX.Y.Z or X.Y.Z; defaults to latest)
   --prefix   Install prefix (defaults to /usr/local or ~/.local)
 
 Environment:
@@ -19,6 +19,8 @@ Environment:
   KSRC_PREFIX        Override prefix
   KSRC_REPO          Override repo (default: respawn-app/ksrc)
   KSRC_RELEASE_BASE  Override release base URL
+  GITHUB_TOKEN       GitHub token for API rate limits
+  GH_TOKEN           GitHub token for API rate limits
 EOF
 }
 
@@ -44,12 +46,60 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | awk -F'"' '/"tag_name":/ {print $4; exit}')"
+  api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  auth_header=""
+  api_headers="$tmpdir/api.headers"
+  api_body="$tmpdir/api.json"
+  api_status=""
+  api_message=""
+  api_rate_limited="0"
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    auth_header="Authorization: Bearer ${GH_TOKEN}"
+  fi
+  if [ -n "$auth_header" ]; then
+    api_status="$(curl -sSL -D "$api_headers" -o "$api_body" -w '%{http_code}' -H "$auth_header" "$api_url" || true)"
+  else
+    api_status="$(curl -sSL -D "$api_headers" -o "$api_body" -w '%{http_code}' "$api_url" || true)"
+  fi
+  if [ "$api_status" = "200" ]; then
+    VERSION="$(awk -F'"' '/"tag_name":/ {print $4; exit}' "$api_body")"
+  else
+    api_message="$(awk -F'"' '/"message":/ {print $4; exit}' "$api_body" || true)"
+    if [ -n "$api_message" ] && echo "$api_message" | grep -qi "API rate limit exceeded"; then
+      api_rate_limited="1"
+    elif grep -qi '^x-ratelimit-remaining: 0' "$api_headers" 2>/dev/null; then
+      api_rate_limited="1"
+    fi
+  fi
 fi
 if [ -z "$VERSION" ]; then
+  latest_url="$(curl -sSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" || true)"
+  case "$latest_url" in
+    */releases/tag/*) VERSION="${latest_url##*/tag/}" ;;
+  esac
+fi
+if [ -z "$VERSION" ]; then
+  if [ "${api_rate_limited:-0}" = "1" ]; then
+    echo "GitHub API rate limit exceeded. Set GITHUB_TOKEN or GH_TOKEN and retry." >&2
+  elif [ -n "${api_message:-}" ]; then
+    echo "$api_message" >&2
+  fi
   echo "Failed to resolve latest version." >&2
   exit 1
+fi
+
+tag="$VERSION"
+if [ "${VERSION#v}" = "$VERSION" ]; then
+  tag="v$VERSION"
 fi
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -74,7 +124,7 @@ case "$arch" in
     ;;
 esac
 
-ver="${VERSION#v}"
+ver="${tag#v}"
 base_name="ksrc_${ver}_${os}_${arch}"
 if [ "$os" = "windows" ]; then
   archive="${base_name}.zip"
@@ -84,14 +134,15 @@ else
   bin_name="${base_name}"
 fi
 
-tmpdir="$(mktemp -d)"
-cleanup() {
-  rm -rf "$tmpdir"
-}
-trap cleanup EXIT
-
-url="${RELEASE_BASE}/${VERSION}/${archive}"
-curl -fsSL "$url" -o "$tmpdir/$archive"
+url="${RELEASE_BASE}/${tag}/${archive}"
+download_status="$(curl -sSL -o "$tmpdir/$archive" -w '%{http_code}' "$url" || true)"
+if [ "$download_status" != "200" ]; then
+  if [ "$download_status" = "404" ]; then
+    echo "Version not found. Try without --version or use vX.Y.Z / X.Y.Z." >&2
+  fi
+  echo "Failed to download ${archive} (HTTP ${download_status})." >&2
+  exit 1
+fi
 
 if [ "$os" = "windows" ]; then
   if ! command -v unzip >/dev/null 2>&1; then
@@ -118,9 +169,13 @@ case "$bin_dir" in
 esac
 
 mkdir -p "$bin_dir"
-install -m 755 "$tmpdir/$bin_name" "$bin_dir/ksrc"
+target="$bin_dir/ksrc"
+if [ -f "$target" ]; then
+  echo "Warning: overwriting existing $target" >&2
+fi
+install -m 755 "$tmpdir/$bin_name" "$target"
 
-echo "Installed ksrc to $bin_dir/ksrc"
+echo "Installed ksrc to $target"
 if ! echo "$PATH" | tr ':' '\n' | grep -q "^${bin_dir}$"; then
   echo "Note: $bin_dir is not on PATH. Add it to your shell profile."
 fi


### PR DESCRIPTION
## Summary
- improve install.sh latest-version lookup with rate-limit detection and fallback to releases/latest redirect
- accept X.Y.Z or vX.Y.Z for --version and clarify 404 guidance
- warn when overwriting existing install

Fixes #9

## Testing
- go test ./...
- go build -o ./bin/ksrc ./cmd/ksrc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible version input (accepts vX.Y.Z or X.Y.Z) and automatic latest-release detection via GitHub API with optional token support
  * Windows package handling and archive/exe-specific install flow

* **Improvements**
  * Robust download and HTTP status handling with API fallback when needed
  * Safer installation: explicit target path, overwrite warnings, and refusal to overwrite directories/symlinks
  * Clearer PATH/install messaging and default prefix/bin handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->